### PR TITLE
add native DLF support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include max_training_framework/setup/config.json
+include templates/*.yaml

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ python metadata_converter/apply.py my.yaml my.template -o my_completed.templat
 
 ## Programmatic invocation
 
-See example code in [`examples/invoke.py`](examples/invoke.py). 
+See example source code in [examples/](examples/).
 
 ## Templates
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+### Generate a generic YAML
+
+Bring your own placeholder file and template YAML. See example code in [`invoke.py`](invoke.py).
+
+### Generate DLF-compatible YAML
+
+Generate a DLF-compatible YAML file. See example code in [`generate_dlf.py`](generate_dlf.py).

--- a/examples/generate_dlf.py
+++ b/examples/generate_dlf.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from metadata_converter.generate import generate_dlf_yaml
+import sys
+import yaml
+
+#
+# This example illustrates how to invoke the exchange metadata converter
+# programatically, using the DLF template
+# Required parameters:
+# /path/to/placeholder/yaml see examples in dax-data-set-descriptors/
+if __name__ == "__main__":
+
+    try:
+
+        if len(sys.argv) != 2:
+            print('Usage: {} {}'
+                  .format(sys.argv[0],
+                          '/path/to/placeholder/yaml'))
+            sys.exit(1)
+
+        with open(sys.argv[1], 'r') as source_yaml:
+            placeholder_yaml = yaml.load(source_yaml,
+                                         Loader=yaml.FullLoader)
+
+        # Generate DLF-compatible YAML by replacing the placeholders
+        # in  "templates/dlf_out.yaml" with values from placeholder_yaml
+        generated_dlf_yaml = generate_dlf_yaml(placeholder_yaml)
+
+        # print template YAML with replacements in place
+        print(generated_dlf_yaml)
+
+    except Exception as ex:
+        print(ex)

--- a/metadata_converter/generate.py
+++ b/metadata_converter/generate.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from importlib_resources import files
+from metadata_converter.apply import replace
+import sys
+import templates
+import yaml
+
+
+def generate_dlf_yaml(in_yaml):
+    """
+    Generate DLF-compatible YAML configuration file using
+    "templates/dlf_out" as template.
+
+    :param in_yaml: dict representation of a YAML document defining
+    placeholder values in "templates/dlf_out.yaml"
+    :type in_yaml: dict
+    :raises PlaceholderNotFoundError: a {{...}} placeholder referenced
+    in "templates/dlf_out.yaml" was not found
+    :raises ValueError in_yaml is not of type dict
+    :return: DLF-compatible YAML file
+    :rtype: dict
+    """
+
+    dlf_yaml = files(templates).joinpath('dlf_out.yaml')
+
+    # load the template YAML
+    with open(dlf_yaml, 'r') as template_yaml:
+        dlf_template_yaml = yaml.load(template_yaml,
+                                      Loader=yaml.FullLoader)
+
+    # replace placeholders in in_template_yaml with values from
+    # in_placeholder_yaml
+    dlf_yaml = replace(in_yaml, dlf_template_yaml)
+
+    return dlf_yaml
+
+
+#
+# This example illustrates how to invoke the exchange metadata converter
+# programatically, using the DLF template
+# Required parameters:
+# /path/to/placeholder/yaml see examples in dax-data-set-descriptors/
+if __name__ == "__main__":
+
+    try:
+
+        if len(sys.argv) != 2:
+            print('Usage: {} {}'
+                  .format(sys.argv[0],
+                          '/path/to/placeholder/yaml'))
+            sys.exit(1)
+
+        with open(sys.argv[1], 'r') as source_yaml:
+            placeholder_yaml = yaml.load(source_yaml,
+                                         Loader=yaml.FullLoader)
+
+        generated_dlf_yaml = generate_dlf_yaml(placeholder_yaml)
+
+        # print template yamls with replacements in place
+        print(generated_dlf_yaml)
+
+    except Exception as ex:
+        print(ex)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open('README.md') as readme:
 setup(
   name='exchange-metadata-converter',
   packages=find_packages(),
-  version='0.0.1',
+  version='0.0.2',
   license='Apache-2.0',
   description='exchange metadata converters',
   long_description=README,
@@ -32,6 +32,7 @@ setup(
   url='https://github.com/CODAIT/exchange-metadata-converter',
   keywords=['YAML templating engine'],
   install_requires=[
+    'importlib-resources',
     'pyyaml'
   ],
   include_package_data=True,


### PR DESCRIPTION
This PR introduces support for `generate_dlf_yaml`, which generates DLF-compatible YAML given A DAX-compatible placeholder YAML (see examples in  `dax-data-set-descriptors/`) as input.