### PR TITLE
Add support for output as data structure and text file

### DIFF
--- a/examples/generate_dlf.py
+++ b/examples/generate_dlf.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 from metadata_converter.generate import generate_dlf_yaml
+from metadata_converter.generate import generate_dlf_yaml_dict
 import sys
 import yaml
 
@@ -38,10 +39,14 @@ if __name__ == "__main__":
 
         # Generate DLF-compatible YAML by replacing the placeholders
         # in  "templates/dlf_out.yaml" with values from placeholder_yaml
-        generated_dlf_yaml = generate_dlf_yaml(placeholder_yaml)
+        generated_dlf_yaml_dict = generate_dlf_yaml_dict(placeholder_yaml)
 
-        # print template YAML with replacements in place
-        print(generated_dlf_yaml)
+        # print DLF-compatible output with replacements in place
+        print('Generated DLF YAML dict: ')
+        print(generated_dlf_yaml_dict)
+
+        print('Generated DLF YAML file: ')
+        print(generate_dlf_yaml(placeholder_yaml))
 
     except Exception as ex:
         print(ex)

--- a/metadata_converter/generate.py
+++ b/metadata_converter/generate.py
@@ -24,7 +24,32 @@ import yaml
 def generate_dlf_yaml(in_yaml):
     """
     Generate DLF-compatible YAML configuration file using
-    "templates/dlf_out" as template.
+    "templates/dlf_out.yaml" as template.
+
+    :param in_yaml: dict representation of a YAML document defining
+    placeholder values in "templates/dlf_out.yaml"
+    :type in_yaml: dict
+    :raises PlaceholderNotFoundError: a {{...}} placeholder referenced
+    in "templates/dlf_out.yaml" was not found
+    :raises ValueError in_yaml is not of type dict
+    :return: DLF-compatible YAML file
+    :rtype: str
+    """
+
+    dlf_yaml_dict = generate_dlf_yaml_dict(in_yaml)
+
+    dlf_yaml = yaml.safe_dump(dlf_yaml_dict,
+                              default_flow_style=False,
+                              allow_unicode=True,
+                              sort_keys=False)
+
+    return dlf_yaml
+
+
+def generate_dlf_yaml_dict(in_yaml):
+    """
+    Generate DLF-compatible YAML configuration using
+    "templates/dlf_out.yaml" as template.
 
     :param in_yaml: dict representation of a YAML document defining
     placeholder values in "templates/dlf_out.yaml"
@@ -45,9 +70,9 @@ def generate_dlf_yaml(in_yaml):
 
     # replace placeholders in in_template_yaml with values from
     # in_placeholder_yaml
-    dlf_yaml = replace(in_yaml, dlf_template_yaml)
+    dlf_yaml_dict = replace(in_yaml, dlf_template_yaml)
 
-    return dlf_yaml
+    return dlf_yaml_dict
 
 
 #
@@ -69,10 +94,14 @@ if __name__ == "__main__":
             placeholder_yaml = yaml.load(source_yaml,
                                          Loader=yaml.FullLoader)
 
-        generated_dlf_yaml = generate_dlf_yaml(placeholder_yaml)
+        generated_dlf_yaml_dict = generate_dlf_yaml(placeholder_yaml)
 
         # print template yamls with replacements in place
-        print(generated_dlf_yaml)
+        print('Generated DLF YAML dict: ')
+        print(generated_dlf_yaml_dict)
+
+        print('Generated DLF YAML file: ')
+        print(generate_dlf_yaml(placeholder_yaml))
 
     except Exception as ex:
         print(ex)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open('README.md') as readme:
 setup(
   name='exchange-metadata-converter',
   packages=find_packages(),
-  version='0.0.2',
+  version='0.0.3',
   license='Apache-2.0',
   description='exchange metadata converters',
   long_description=README,


### PR DESCRIPTION
This PR enables output as line separated string `generate_dlf_yaml` and dict `generate_dlf_yaml_dict`. The example was update to illustrate both.