### PR TITLE
add initial support for OpenAIHub template 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,7 @@ Bring your own placeholder file and template YAML. See example code in [`invoke.
 ### Generate DLF-compatible YAML
 
 Generate a DLF-compatible YAML file. See example code in [`generate_dlf.py`](generate_dlf.py).
+
+### Generate OpenAIHub-compatible YAML
+
+Generate a OpenAIHub-compatible YAML file. See example code in [`generate_openaihub.py`](generate_openaihub.py).

--- a/examples/generate_openaihub.py
+++ b/examples/generate_openaihub.py
@@ -1,0 +1,52 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from metadata_converter.generate import generate_oah_yaml
+from metadata_converter.generate import generate_oah_yaml_dict
+import sys
+import yaml
+
+#
+# This example illustrates how to invoke the exchange metadata converter
+# programmatically, using the DLF template
+# Required parameters:
+# /path/to/placeholder/yaml see examples in dax-data-set-descriptors/
+if __name__ == "__main__":
+
+    try:
+
+        if len(sys.argv) != 2:
+            print('Usage: {} {}'
+                  .format(sys.argv[0],
+                          '/path/to/placeholder/yaml'))
+            sys.exit(1)
+
+        with open(sys.argv[1], 'r') as source_yaml:
+            placeholder_yaml = yaml.load(source_yaml,
+                                         Loader=yaml.FullLoader)
+
+        # Generate OpenAIHub-compatible YAML by replacing the placeholders
+        # in  "templates/openaihub_out.yaml" with values from placeholder_yaml
+        generated_dlf_yaml_dict = generate_oah_yaml_dict(placeholder_yaml)
+
+        # print OpenAIHub-compatible output with replacements in place
+        print('Generated DLF YAML dict: ')
+        print(generated_dlf_yaml_dict)
+
+        print('Generated OpenAIHub YAML file: ')
+        print(generate_oah_yaml(placeholder_yaml))
+
+    except Exception as ex:
+        print(ex)

--- a/metadata_converter/generate.py
+++ b/metadata_converter/generate.py
@@ -75,9 +75,63 @@ def generate_dlf_yaml_dict(in_yaml):
     return dlf_yaml_dict
 
 
+def generate_oah_yaml(in_yaml):
+    """
+    Generate OpenAIHub-compatible YAML configuration file using
+    "templates/openaihub_out.yaml" as template.
+
+    :param in_yaml: dict representation of a YAML document defining
+    placeholder values in "templates/openaihub_out.yaml"
+    :type in_yaml: dict
+    :raises PlaceholderNotFoundError: a {{...}} placeholder referenced
+    in "templates/openaihub_out.yaml" was not found
+    :raises ValueError in_yaml is not of type dict
+    :return: OpenAIHub-compatible YAML file
+    :rtype: str
+    """
+
+    oah_yaml_dict = generate_oah_yaml_dict(in_yaml)
+
+    oah_yaml = yaml.safe_dump(oah_yaml_dict,
+                              default_flow_style=False,
+                              allow_unicode=True,
+                              sort_keys=False)
+
+    return oah_yaml
+
+
+def generate_oah_yaml_dict(in_yaml):
+    """
+    Generate OpenAIHub-compatible YAML configuration using
+    "templates/openaihub_out.yaml" as template.
+
+    :param in_yaml: dict representation of a YAML document defining
+    placeholder values in "templates/openaihub_out.yaml"
+    :type in_yaml: dict
+    :raises PlaceholderNotFoundError: a {{...}} placeholder referenced
+    in "templates/openaihub_out.yaml" was not found
+    :raises ValueError in_yaml is not of type dict
+    :return: OpenAIHub-compatible YAML file
+    :rtype: dict
+    """
+
+    oah_yaml = files(templates).joinpath('openaihub_out.yaml')
+
+    # load the template YAML
+    with open(oah_yaml, 'r') as template_yaml:
+        oah_template_yaml = yaml.load(template_yaml,
+                                      Loader=yaml.FullLoader)
+
+    # replace placeholders in in_template_yaml with values from
+    # in_placeholder_yaml
+    oah_yaml_dict = replace(in_yaml, oah_template_yaml)
+
+    return oah_yaml_dict
+
+
 #
 # This example illustrates how to invoke the exchange metadata converter
-# programmatically, using the DLF template
+# programmatically, using the DLF and OpenAIHub templates
 # Required parameters:
 # /path/to/placeholder/yaml see examples in dax-data-set-descriptors/
 if __name__ == "__main__":
@@ -94,14 +148,18 @@ if __name__ == "__main__":
             placeholder_yaml = yaml.load(source_yaml,
                                          Loader=yaml.FullLoader)
 
-        generated_dlf_yaml_dict = generate_dlf_yaml(placeholder_yaml)
-
         # print template yamls with replacements in place
-        print('Generated DLF YAML dict: ')
-        print(generated_dlf_yaml_dict)
+        print('Generated DLF YAML dict: \n{}'
+              .format(generate_dlf_yaml_dict(placeholder_yaml)))
 
-        print('Generated DLF YAML file: ')
-        print(generate_dlf_yaml(placeholder_yaml))
+        print('Generated DLF YAML: \n{}'
+              .format(generate_dlf_yaml(placeholder_yaml)))
+
+        print('Generated OpenAIHub YAML dict: \n{}'
+              .format(generate_oah_yaml_dict(placeholder_yaml)))
+
+        print('Generated OpenAIHub YAML: \n{}'
+              .format(generate_oah_yaml(placeholder_yaml)))
 
     except Exception as ex:
         print(ex)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open('README.md') as readme:
 setup(
   name='exchange-metadata-converter',
   packages=find_packages(),
-  version='0.0.3',
+  version='0.0.4',
   license='Apache-2.0',
   description='exchange metadata converters',
   long_description=README,

--- a/templates/openaihub_out.yaml
+++ b/templates/openaihub_out.yaml
@@ -14,8 +14,23 @@
 apiVersion: com.ibm/v1alpha1
 kind: Dataset
 metadata:
-  name: {{name}}
+  name: '{{name}}'
+  labels:
+    id: '{{id}}'
+    description: '{{description}}'
+    version: '{{version}}'
+    created: '{{created}}'
+    updated: '{{updated}}'
+    format: '{{format}}'
+    domain: '{{domain}}'
+    provider: '{{provider}}'
+    repository: '{{repository}}'
+    license: '{{license}}'
+    content:
+    source: '{{source}}'
+    seo_tags: '{{seo_tags}}'
+    related_assets: '{{related_assets}}'
 spec:
   type: "ARCHIVE"
-  url: {{repository.url}}
-  format: {{repository.mime_type}}
+  url: '{{repository.url}}'
+  format: '{{repository.mime_type}}'

--- a/tests/test_oah.py
+++ b/tests/test_oah.py
@@ -19,23 +19,15 @@ import unittest
 import yaml
 
 #
-# Tests DLF template (templates/dlf_out.yaml)
+# Tests OpenAIHub template (templates/openaihub_out.yaml)
 #
 
 
-class TestDLF(unittest.TestCase):
+class TestOAH(unittest.TestCase):
 
     def setUp(self):
 
-        self.placeholder_file = 'dax-data-set-descriptors/lorem_ipsum.yaml'
-
-        with open(self.placeholder_file, 'r') as source_yaml:
-            self.in_yamls = list(yaml.load_all(source_yaml,
-                                               Loader=yaml.FullLoader))
-
-        self.assertTrue(len(self.in_yamls) == 1)
-
-        self.template_file = 'templates/dlf_out.yaml'
+        self.template_file = 'templates/openaihub_out.yaml'
 
         with open(self.template_file, 'r') as template_yaml:
             self.template_yamls = list(yaml.load_all(template_yaml,
@@ -43,33 +35,13 @@ class TestDLF(unittest.TestCase):
 
         self.assertTrue(len(self.template_yamls) == 1)
 
-    def test_dtest_dlf(self):
-
-        try:
-            out_dict = replace(self.in_yamls[0], self.template_yamls[0])
-            self.assertTrue(out_dict is not None)
-            self.assertTrue(isinstance(out_dict, dict))
-            self.assertEqual(out_dict['apiVersion'], 'com.ibm/v1alpha1')
-            self.assertEqual(out_dict['kind'], 'Dataset')
-            self.assertEqual(out_dict['metadata']['name'],
-                             self.in_yamls[0]['name'])
-            self.assertEqual(out_dict['metadata']['labels']['version'],
-                             self.in_yamls[0]['version'])
-            self.assertEqual(out_dict['spec']['type'],
-                             'ARCHIVE')
-            self.assertEqual(out_dict['spec']['url'],
-                             self.in_yamls[0]['repository']['url'])
-            self.assertEqual(out_dict['spec']['format'],
-                             self.in_yamls[0]['repository']['mime_type'])
-        except Exception as e:
-            self.assertTrue(False, e)
-
     def test_dax_dataset_descriptors(self):
 
         # Verify that the DAX data set descriptors in dax-data-set-descriptors
         # don't raise any exceptions during processing. For example, an
-        # exception is raised if the DLF YAML template contains a placeholder
-        # that is not defined.
+        # exception is raised if the OpenAIHub YAML template contains a
+        # placeholder that is not defined.
+
         error_count = 0
         for descriptor in glob.iglob('dax-data-set-descriptors/*.yaml'):
             with open(descriptor, 'r') as source_yaml:


### PR DESCRIPTION
This PR
  - Updates the openaihub YAML template
  - Updates the READMEs
  - Adds OpenAIHub examples
 - Adds tests that verify that the YAML files in `dax-data-set-descriptors` define all placeholders referenced in the DLF and OpenDataHub YAML templates.