### PR TITLE
initial support for annotations + optional properties

### DIFF
--- a/metadata_converter/apply.py
+++ b/metadata_converter/apply.py
@@ -78,7 +78,7 @@ def replace(yaml_dict, template_dict):
             for match in re.finditer('@([a-zA-Z]+)',
                                      metadata['comment'],
                                      re.I):
-                metadata['annotations'].add(match.group(1))
+                metadata['annotations'].add(match.group(1).lower())
             # Remove noise from the comment, such as annotations
             # comment characters and whitespace characters
             #  - Remove annotations

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open('README.md') as readme:
 setup(
   name='exchange-metadata-converter',
   packages=find_packages(),
-  version='0.0.6',
+  version='0.0.7',
   license='Apache-2.0',
   description='exchange metadata converters',
   long_description=README,

--- a/tests/inputs/annotations.yaml
+++ b/tests/inputs/annotations.yaml
@@ -1,0 +1,6 @@
+# This YAML document does not define the following properties:
+# noprop1value, noprop2value, noprop3value, noprop3value,
+# noprop4value, noprop5value, noprop6value
+unused_property: True
+hey:
+  we_are_a_match: 'Then let us pair up!'

--- a/tests/templates/annotations.yaml
+++ b/tests/templates/annotations.yaml
@@ -14,14 +14,22 @@ property7:
                                 #  
                                 # an @optional property
                                 # we are @very @very @lucky
-property9:
+property9:                           # annotations work in dicts
   property10:
     property11: '{{noprop11value}}'  # this @optional property
                                      # is @fine
-property12:
+property12:                           # annotations work in lists
   - property12a: '{{hey.we_are_a_match}}'   # @optional does not apply
     property12b: '{{noprop12bvalue}}' # sweet, it's @optional
     property12c: a_constant!
+property13:                             # annotations are case insensitive
+  property14: 
+    property15:
+      property16a: '{{noprop16avalue}}' # @OPTIONAL
+      property16b: '{{noprop16bvalue}}' # an @Optional property
+      property16c: '{{noprop16cvalue}}' # another @OptioNAl property
+    property17:  all is good            # Nothing @opTioNAL here
+    property18: '{{hey.we_are_a_match}}'# nothing @OPTIONal here either
 ---
 property1: '{{noprop1value}}' #
 ---

--- a/tests/templates/annotations.yaml
+++ b/tests/templates/annotations.yaml
@@ -1,0 +1,38 @@
+# test level-0 properties; each one is annotated with
+# <at>optional and should therefore not raise an error
+property1: '{{noprop1value}}' # @optional
+property2: '{{noprop2value}}' # comment @optional
+property3: '{{noprop3value}}' # more comments @optional
+property4: '{{noprop4value}}' # more @optional comments
+property5: '{{noprop5value}}' # more @bogus comments @optional
+property6: '{{noprop6value}}' # more 
+                              # @bogus comments
+                              #  
+                              # @optional
+property7:
+  property8: '{{noprop8value}}' # property8 is
+                                #  
+                                # an @optional property
+                                # we are @very @very @lucky
+property9:
+  property10:
+    property11: '{{noprop11value}}'  # this @optional property
+                                     # is @fine
+property12:
+  - property12a: '{{hey.we_are_a_match}}'   # @optional does not apply
+    property12b: '{{noprop12bvalue}}' # sweet, it's @optional
+    property12c: a_constant!
+---
+property1: '{{noprop1value}}' #
+---
+property1: '{{noprop1value}}' # just a comment
+---
+property1: '{{noprop1value}}' # @notarecognizedannotation
+---
+property1: '{{noprop1value}}' # more
+                              # is not always @better
+                              #
+---
+property1:                          # @optional does not apply
+  property1a: '{{noprop1avalue}}'   # because we fail here
+

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -63,6 +63,22 @@ class TestAnnotations(unittest.TestCase):
             self.assertEqual(
                 self.template_yamls[0]['property12'][0]['property12c'],
                 out_dict['property12'][0]['property12c'])
+            self.assertIsNone(
+                out_dict['property13']['property14']
+                        ['property15']['property16a'])
+            self.assertIsNone(
+                out_dict['property13']['property14']
+                        ['property15']['property16b'])
+            self.assertIsNone(
+                out_dict['property13']['property14']
+                        ['property15']['property16c'])
+            self.assertEqual(out_dict['property13']
+                             ['property14']['property17'],
+                             self.template_yamls[0]['property13']['property14']
+                             ['property17'])
+            self.assertEqual(out_dict['property13']
+                             ['property14']['property18'],
+                             self.in_yamls['hey']['we_are_a_match'])
         except Exception as e:
             self.assertTrue(False, e)
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,98 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from metadata_converter.apply import replace
+from metadata_converter.apply import PlaceholderNotFoundError
+from pathlib import Path
+from ruamel.yaml import YAML
+import unittest
+
+yaml = YAML()
+yaml.default_flow_style = False
+
+#
+# Tests template annotations: @optional
+#
+
+
+class TestAnnotations(unittest.TestCase):
+
+    def setUp(self):
+
+        self.placeholder_file = 'tests/inputs/annotations.yaml'
+
+        self.in_yamls = yaml.load(Path(self.placeholder_file))
+
+        self.template_file = 'tests/templates/annotations.yaml'
+
+        self.template_yamls = list(yaml.load_all(Path(self.template_file)))
+        self.assertEqual(len(self.template_yamls), 6)
+
+    def test_optional_annotation(self):
+
+        try:
+            out_dict = replace(self.in_yamls, self.template_yamls[0])
+            self.assertTrue(out_dict is not None)
+            self.assertTrue(isinstance(out_dict, dict))
+            self.assertIsNone(out_dict['property1'])
+            self.assertIsNone(out_dict['property2'])
+            self.assertIsNone(out_dict['property3'])
+            self.assertIsNone(out_dict['property4'])
+            self.assertIsNone(out_dict['property5'])
+            self.assertIsNone(out_dict['property6'])
+            self.assertIsNone(out_dict['property7']['property8'])
+            self.assertIsNone(
+                out_dict['property9']['property10']['property11'])
+            self.assertEqual(
+                out_dict['property12'][0]['property12a'],
+                self.in_yamls['hey']['we_are_a_match'])
+            self.assertIsNone(
+                out_dict['property12'][0]['property12b'])
+            self.assertEqual(
+                self.template_yamls[0]['property12'][0]['property12c'],
+                out_dict['property12'][0]['property12c'])
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def test_without_optional_annotation(self):
+
+        # self.template_yamls contains multipe documents with
+        # references to an undefined placeholder
+        for index in [1, 2, 3, 4]:
+            try:
+                # should fail
+                replace(self.in_yamls, self.template_yamls[index])
+                self.assertTrue(False)
+            except PlaceholderNotFoundError as pnfe:
+                self.assertEqual('{{' + pnfe.placeholder + '}}',
+                                 self.template_yamls[index]['property1'])
+            except Exception as e:
+                self.assertTrue(False, e)
+
+        for index in [5]:
+            try:
+                # should fail
+                replace(self.in_yamls, self.template_yamls[index])
+                self.assertTrue(False)
+            except PlaceholderNotFoundError as pnfe:
+                self.assertEqual('{{' + pnfe.placeholder + '}}',
+                                 self.template_yamls[index]
+                                 .get('property1').get('property1a'))
+            except Exception as e:
+                self.assertTrue(False, e)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces the concept of annotations. In template file properties can now be annotated and marked as optional by adding a comment and specifying the `@optional` annotation:

```
property: '{{lookup_key}}'           # @optional
```
 
If the placeholder `lookup_key` cannot be located in the placeholder file, `None/null` will be assigned if the annotation was specified. Without the annotation present an `PlaceholderNotFoundError` is raised, as it was done before. 

Annotations are case insensitive, meaning `@optional` is identical to `@OPTIONAL`, `@OPTIONal` etc. 

Where in a comment an annotation is specified does not matter:
- `propertyX: '{{placeholder}}'      #        @optional @unknownannotation` 
- `propertyX: '{{placeholder}}'      # @optional comment` 
- `propertyX: '{{placeholder}}'      #  placeholder is @optional` 
- `propertyX: '{{placeholder}}'      # this @optional  comment is rather @short` 

The `@optional` annotation does not apply if the following constructs are encountered in the template YAML file:
- `propertyX: `                         # no placeholder present; `@optional` does not apply
- `propertyY:   valueY`          # no placeholder present; `@optional` does not apply

Closes #24 