### PR TITLE
Replace m-dash (\u2013) in dataset IDs

### DIFF
--- a/dax-data-set-descriptors/gmb.yaml
+++ b/dax-data-set-descriptors/gmb.yaml
@@ -1,5 +1,5 @@
-id: groningen-meaning-bank–modified
-name: Groningen Meaning Bank – Modified
+id: groningen-meaning-bank-modified
+name: Groningen Meaning Bank - Modified
 description: A subset of the GMB dataset, consisting of documents verified to be in the public domain.
 version: 1.0.2
 created: 2020-05-14

--- a/dax-data-set-descriptors/jfk.yaml
+++ b/dax-data-set-descriptors/jfk.yaml
@@ -1,5 +1,5 @@
-id: noaa-weather-data–jfk-airport
-name: NOAA Weather Data – JFK Airport
+id: noaa-weather-data-jfk-airport
+name: NOAA Weather Data - JFK Airport
 description: Local climatological data originally collected at JFK airport.
 version: 1.1.4
 created: 2019-07-19

--- a/dax-data-set-descriptors/jfk.yaml
+++ b/dax-data-set-descriptors/jfk.yaml
@@ -14,7 +14,7 @@ provider:
   name: Data Asset eXchange
   url: https://developer.ibm.com/exchanges/data/all/jfk-weather-data/
 
-# identifies where the data set is stored and how it is stored (REQUIRED)
+# REQUIRED; identifies where the data set is stored and how it is stored
 repository:
   type: HTTP
   url: https://dax-cdn.cdn.appdomain.cloud/dax-noaa-weather-data-jfk-airport/1.1.4/noaa-weather-data-jfk-airport.tar.gz


### PR DESCRIPTION
To avoid the following error when storing the `id` in a MySQL database: 

```
illegal mix of collations (latin1_general_cs,IMPLICIT) and (latin1_general_ci,IMPLICIT)
```